### PR TITLE
APILIB-22: Update python-api to support new format of evidence source

### DIFF
--- a/examples/diagnosis.py
+++ b/examples/diagnosis.py
@@ -10,8 +10,8 @@ if __name__ == '__main__':
 
     request = infermedica_api.Diagnosis(sex='female', age=35)
 
-    request.add_symptom('s_21', 'present', initial=True)
-    request.add_symptom('s_98', 'present', initial=True)
+    request.add_symptom('s_21', 'present', source='initial')
+    request.add_symptom('s_98', 'present', source='initial')
     request.add_symptom('s_107', 'absent')
 
     # call diagnosis
@@ -23,6 +23,9 @@ if __name__ == '__main__':
     request.add_symptom('s_99', 'present')
     request.add_symptom('s_8', 'absent')
     request.add_symptom('s_25', 'present')
+    request.add_symptom('s_418', 'present', source='suggest')
+    request.add_symptom('s_18', 'present', source='predefined')
+    request.add_symptom('s_10', 'present', source='red_flags')
     # ... and so on until you decided that enough question have been asked
     # or you have sufficient results in request.conditions
 

--- a/examples/diagnosis.py
+++ b/examples/diagnosis.py
@@ -12,6 +12,9 @@ if __name__ == '__main__':
 
     request.add_symptom('s_21', 'present', source='initial')
     request.add_symptom('s_98', 'present', source='initial')
+    request.add_symptom('s_418', 'present', source='suggest')
+    request.add_symptom('s_18', 'present', source='predefined')
+    request.add_symptom('s_10', 'present', source='red_flags')
     request.add_symptom('s_107', 'absent')
 
     # call diagnosis
@@ -23,9 +26,6 @@ if __name__ == '__main__':
     request.add_symptom('s_99', 'present')
     request.add_symptom('s_8', 'absent')
     request.add_symptom('s_25', 'present')
-    request.add_symptom('s_418', 'present', source='suggest')
-    request.add_symptom('s_18', 'present', source='predefined')
-    request.add_symptom('s_10', 'present', source='red_flags')
     # ... and so on until you decided that enough question have been asked
     # or you have sufficient results in request.conditions
 

--- a/infermedica_api/models/diagnosis.py
+++ b/infermedica_api/models/diagnosis.py
@@ -123,10 +123,11 @@ class Diagnosis(ModelCommon):
             "id": _id,
             "choice_id": state
         }
-        if initial is not None:
+        if initial:
+            evidence['initial'] = True
             warnings.warn(
-                "Parameter initial is deprecated, please use source with following parameter: initial, suggest, "
-                "predefined, red_flags.", category=DeprecationWarning
+                "Parameter initial=True is deprecated, please use source='initial' instead.",
+                category=DeprecationWarning
             )
         if time:
             evidence['observed_at'] = time
@@ -135,7 +136,7 @@ class Diagnosis(ModelCommon):
 
         collection.append(evidence)
 
-    def add_observation(self, _id, state, time=None, source=None):
+    def add_observation(self, _id, state, time=None, initial=None, source=None):
         """
         Adds observation with given presence to evidence list.
 
@@ -148,9 +149,9 @@ class Diagnosis(ModelCommon):
         """
         warnings.warn("Function add_observation is deprecated, please use add_symptom.",
                       category=DeprecationWarning)
-        self.add_symptom(_id, state, time, source)
+        self.add_symptom(_id, state, time, initial, source)
 
-    def add_symptom(self, _id, state, time=None, source=None):
+    def add_symptom(self, _id, state, time=None, initial=None, source=None):
         """
         Adds symptom with given presence to evidence list.
 
@@ -163,9 +164,9 @@ class Diagnosis(ModelCommon):
         :param source: (optional) All symptoms and risk factors: initial, suggest, predefined, red_flags
         :type source: str
         """
-        self.__add_evidence(self.symptoms, _id, state, time, source=source)
+        self.__add_evidence(self.symptoms, _id, state, time, initial=initial, source=source)
 
-    def add_lab_test(self, _id, state, time=None, source=None):
+    def add_lab_test(self, _id, state, time=None, initial=None, source=None):
         """
         Adds laboratory test with given presence to evidence list.
 
@@ -176,9 +177,9 @@ class Diagnosis(ModelCommon):
         :param time: (optional) Laboratory test occurrence time (ISO8601 formatted)
         :type time: str
         """
-        self.__add_evidence(self.lab_tests, _id, state, time, source=source)
+        self.__add_evidence(self.lab_tests, _id, state, time, initial=initial, source=source)
 
-    def add_risk_factor(self, _id, state, time=None, source=None):
+    def add_risk_factor(self, _id, state, time=None, initial=None, source=None):
         """
         Adds risk factor with given presence to evidence list.
 
@@ -190,9 +191,9 @@ class Diagnosis(ModelCommon):
         :param time: (optional) Risk factor occurrence time (ISO8601 formatted)
         :type time: str
         """
-        self.__add_evidence(self.risk_factors, _id, state, time, source=source)
+        self.__add_evidence(self.risk_factors, _id, state, time, initial=initial, source=source)
 
-    def add_evidence(self, _id, state, time=None, source=None):
+    def add_evidence(self, _id, state, time=None, initial=None, source=None):
         """
         Adds evidence with given presence to evidence list.
 
@@ -211,7 +212,7 @@ class Diagnosis(ModelCommon):
         elif _id.startswith("lt_"):
             evidence_list = self.lab_tests
 
-        self.__add_evidence(evidence_list, _id, state, time, source)
+        self.__add_evidence(evidence_list, _id, state, time, initial=initial, source=source)
 
     def set_pursued_conditions(self, pursued):
         """

--- a/infermedica_api/models/diagnosis.py
+++ b/infermedica_api/models/diagnosis.py
@@ -117,7 +117,7 @@ class Diagnosis(ModelCommon):
     def observations(self):
         return self.symptoms
 
-    def __add_evidence(self, collection, _id, state, time, initial):
+    def __add_evidence(self, collection, _id, state, time, source):
         """Helper function to update evidence list."""
         evidence = {
             "id": _id,
@@ -127,12 +127,12 @@ class Diagnosis(ModelCommon):
         if time:
             evidence['observed_at'] = time
 
-        if initial:
-            evidence['initial'] = True
+        if source:
+            evidence['source'] = source
 
         collection.append(evidence)
 
-    def add_observation(self, _id, state, time=None, initial=None):
+    def add_observation(self, _id, state, time=None, source=None):
         """
         Adds observation with given presence to evidence list.
 
@@ -145,9 +145,9 @@ class Diagnosis(ModelCommon):
         """
         warnings.warn("Function add_observation is deprecated, please use add_symptom.",
                       category=DeprecationWarning)
-        self.add_symptom(_id, state, time, initial)
+        self.add_symptom(_id, state, time, source)
 
-    def add_symptom(self, _id, state, time=None, initial=None):
+    def add_symptom(self, _id, state, time=None, source=None):
         """
         Adds symptom with given presence to evidence list.
 
@@ -157,10 +157,12 @@ class Diagnosis(ModelCommon):
         :type state: str
         :param time: (optional) Symptom occurrence time (ISO8601 formatted)
         :type time: str
+        :param source: (optional) All symptoms and risk factors: initial, suggest, predefined, red_flags
+        :type source: str
         """
-        self.__add_evidence(self.symptoms, _id, state, time, initial)
+        self.__add_evidence(self.symptoms, _id, state, time, source)
 
-    def add_lab_test(self, _id, state, time=None, initial=None):
+    def add_lab_test(self, _id, state, time=None, source=None):
         """
         Adds laboratory test with given presence to evidence list.
 
@@ -171,9 +173,9 @@ class Diagnosis(ModelCommon):
         :param time: (optional) Laboratory test occurrence time (ISO8601 formatted)
         :type time: str
         """
-        self.__add_evidence(self.lab_tests, _id, state, time, initial)
+        self.__add_evidence(self.lab_tests, _id, state, time, source)
 
-    def add_risk_factor(self, _id, state, time=None, initial=None):
+    def add_risk_factor(self, _id, state, time=None, source=None):
         """
         Adds risk factor with given presence to evidence list.
 
@@ -185,9 +187,9 @@ class Diagnosis(ModelCommon):
         :param time: (optional) Risk factor occurrence time (ISO8601 formatted)
         :type time: str
         """
-        self.__add_evidence(self.risk_factors, _id, state, time, initial)
+        self.__add_evidence(self.risk_factors, _id, state, time, source)
 
-    def add_evidence(self, _id, state, time=None, initial=None):
+    def add_evidence(self, _id, state, time=None, source=None):
         """
         Adds evidence with given presence to evidence list.
 
@@ -206,7 +208,7 @@ class Diagnosis(ModelCommon):
         elif _id.startswith("lt_"):
             evidence_list = self.lab_tests
 
-        self.__add_evidence(evidence_list, _id, state, time, initial)
+        self.__add_evidence(evidence_list, _id, state, time, source)
 
     def set_pursued_conditions(self, pursued):
         """

--- a/infermedica_api/models/diagnosis.py
+++ b/infermedica_api/models/diagnosis.py
@@ -124,8 +124,10 @@ class Diagnosis(ModelCommon):
             "choice_id": state
         }
         if initial is not None:
-            warnings.warn("Parameter initial is deprecated, please use source.",
-                          category=DeprecationWarning)
+            warnings.warn(
+                "Parameter initial is deprecated, please use source with following parameter: initial, suggest, "
+                "predefined, red_flags.", category=DeprecationWarning
+            )
         if time:
             evidence['observed_at'] = time
         if source:

--- a/infermedica_api/models/diagnosis.py
+++ b/infermedica_api/models/diagnosis.py
@@ -117,16 +117,17 @@ class Diagnosis(ModelCommon):
     def observations(self):
         return self.symptoms
 
-    def __add_evidence(self, collection, _id, state, time, source):
+    def __add_evidence(self, collection, _id, state, time, initial=None, source=None):
         """Helper function to update evidence list."""
         evidence = {
             "id": _id,
             "choice_id": state
         }
-
+        if initial is not None:
+            warnings.warn("Parameter initial is deprecated, please use source.",
+                          category=DeprecationWarning)
         if time:
             evidence['observed_at'] = time
-
         if source:
             evidence['source'] = source
 
@@ -160,7 +161,7 @@ class Diagnosis(ModelCommon):
         :param source: (optional) All symptoms and risk factors: initial, suggest, predefined, red_flags
         :type source: str
         """
-        self.__add_evidence(self.symptoms, _id, state, time, source)
+        self.__add_evidence(self.symptoms, _id, state, time, source=source)
 
     def add_lab_test(self, _id, state, time=None, source=None):
         """
@@ -173,7 +174,7 @@ class Diagnosis(ModelCommon):
         :param time: (optional) Laboratory test occurrence time (ISO8601 formatted)
         :type time: str
         """
-        self.__add_evidence(self.lab_tests, _id, state, time, source)
+        self.__add_evidence(self.lab_tests, _id, state, time, source=source)
 
     def add_risk_factor(self, _id, state, time=None, source=None):
         """
@@ -187,7 +188,7 @@ class Diagnosis(ModelCommon):
         :param time: (optional) Risk factor occurrence time (ISO8601 formatted)
         :type time: str
         """
-        self.__add_evidence(self.risk_factors, _id, state, time, source)
+        self.__add_evidence(self.risk_factors, _id, state, time, source=source)
 
     def add_evidence(self, _id, state, time=None, source=None):
         """


### PR DESCRIPTION
API now support different way to pass source information. The library should follow the latest structure.

